### PR TITLE
possible fixes for compilation error

### DIFF
--- a/src/sim/fiber_prop.cc
+++ b/src/sim/fiber_prop.cc
@@ -289,7 +289,7 @@ void FiberProp::clear()
 #endif
 #if NEW_END_FORCE
     /* Brady Berg, 10/26/2023 */
-    end_force.clear();
+    end_force           = Vector2(0.0,0.0);
 #endif
 #if NEW_FIBER_CHEW
     max_chewing_speed   = 0;

--- a/src/sim/fiber_prop.h
+++ b/src/sim/fiber_prop.h
@@ -7,6 +7,7 @@
 #include "property.h"
 #include "common.h"
 #include "sim.h"
+#include "vector.h"
 
 class Field;
 class Fiber;


### PR DESCRIPTION
- fiber_prop now uses a Vector, so it needs to include the definition of the Vector class, contained in the header "fiber_prop.h" and the source file "vector2.h" (for 2-dimensional vectors). 
- The definition of Vector class in vector2.cc doesn't have a clear() method. But it has an initializer. So I used the initializer with a (0,0) vector. 

On my machine, it compiles with these two changes.